### PR TITLE
test: add Ktor integration test baseline with isolated test DB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,4 +45,14 @@ dependencies {
 
     // simple logging
     implementation("org.slf4j:slf4j-simple:2.0.7")
+
+    // testing
+    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
+    testImplementation(kotlin("test"))
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/com/flightbooking/Application.kt
+++ b/src/main/kotlin/com/flightbooking/Application.kt
@@ -36,6 +36,22 @@ fun main(args: Array<String>) {
  * initialises the database, and registers all routes.
  */
 fun Application.module() {
+    configureServer()
+    initialiseDatabase()
+    registerRoutes()
+}
+
+/**
+ * Test module for Ktor server testing.
+ * Accepts an override DB url so tests never touch the real DB file.
+ */
+fun Application.testModule(testDbUrl: String) {
+    configureServer()
+    initialiseDatabase(url = testDbUrl)
+    registerRoutes()
+}
+
+private fun Application.configureServer() {
     install(CallLogging) {
         level = Level.INFO
     }
@@ -73,16 +89,23 @@ fun Application.module() {
             cookie.httpOnly = true
         }
     }
+}
 
+private fun Application.initialiseDatabase(url: String? = null) {
     // Start up DB abstraction instance
-    
     try {
-        DBFactory.init()
+        if (url == null) {
+            DBFactory.init()
+        } else {
+            DBFactory.init(url = url)
+        }
     } catch (e: Throwable) {
         log.error("Failed to init DBFactory", e)
         dispose() // gracefull exit instead of abrupt error thrown
     }
+}
 
+private fun Application.registerRoutes() {
     // Prepare and load the routes
     routing {
         staticResources("/static", "static") // allows easy stylesheet reference (like pebble "templates" prefix)

--- a/src/main/kotlin/com/flightbooking/database/DatabaseFactory.kt
+++ b/src/main/kotlin/com/flightbooking/database/DatabaseFactory.kt
@@ -13,16 +13,22 @@ import com.flightbooking.tables.*
  * tables exist, creating any that are missing via tables in Tables.kt
  */
 object DBFactory {
+    private const val DEFAULT_URL = "jdbc:sqlite:data/flight_booking_DB.db"
+    private const val DEFAULT_DRIVER = "org.sqlite.JDBC"
+
     /**
      * Initialised connection to database and checks for/creates missing tables
      * 
      * @throws SQLException/ExposedSQLException if the database connection/table connect fails
      */
 
-    fun init() {
+    fun init(
+        url: String = DEFAULT_URL,
+        driver: String = DEFAULT_DRIVER
+    ) {
         Database.connect(
-            url = "jdbc:sqlite:data/flight_booking_DB.db",
-            driver = "org.sqlite.JDBC"
+            url = url,
+            driver = driver
         )
         println("Checking if all tables exist...")
         transaction {

--- a/src/test/kotlin/com/flightbooking/ApplicationTest.kt
+++ b/src/test/kotlin/com/flightbooking/ApplicationTest.kt
@@ -1,0 +1,127 @@
+package com.flightbooking
+
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ApplicationTest {
+    private val tempDbFiles = mutableListOf<Path>()
+
+    @AfterTest
+    fun cleanupTempDatabases() {
+        tempDbFiles.forEach { it.deleteIfExists() }
+        tempDbFiles.clear()
+    }
+
+    @Test
+    fun loginPageLoads() = testApplication {
+        configureApp(newTestDbUrl())
+
+        val response = client.get("/login")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("Login"))
+    }
+
+    @Test
+    fun unauthenticatedHomeRedirectsToLogin() = testApplication {
+        configureApp(newTestDbUrl())
+        val client = createClient { followRedirects = false }
+
+        val response = client.get("/home")
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals("/login", response.headers[HttpHeaders.Location])
+    }
+
+    @Test
+    fun registerThenLoginRedirectsToHomeAndSetsSessionCookie() = testApplication {
+        configureApp(newTestDbUrl())
+        val client = createClient { followRedirects = false }
+
+        val registerResponse = client.post("/register") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                listOf(
+                    "email" to "student@example.com",
+                    "password" to "Password123!",
+                    "firstName" to "Stu",
+                    "lastName" to "Dent"
+                ).formUrlEncode()
+            )
+        }
+        assertEquals(HttpStatusCode.Found, registerResponse.status)
+        assertEquals("/login", registerResponse.headers[HttpHeaders.Location])
+
+        val loginResponse = client.post("/login") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                listOf(
+                    "email" to "student@example.com",
+                    "password" to "Password123!"
+                ).formUrlEncode()
+            )
+        }
+        assertEquals(HttpStatusCode.Found, loginResponse.status)
+        assertEquals("/home", loginResponse.headers[HttpHeaders.Location])
+        assertNotNull(loginResponse.headers.getAll(HttpHeaders.SetCookie)?.find { it.contains("USER_SESSION") })
+    }
+
+    @Test
+    fun staffRegisterRejectsWrongInviteCode() = testApplication {
+        configureApp(newTestDbUrl())
+
+        val response = client.post("/staff/register") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                listOf(
+                    "firstName" to "Alex",
+                    "lastName" to "Admin",
+                    "email" to "staff@example.com",
+                    "password" to "StrongPass123!",
+                    "role" to "admin",
+                    "inviteCode" to "WRONG-CODE"
+                ).formUrlEncode()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid invite code"))
+    }
+
+    @Test
+    fun unauthenticatedStaffFlightsRedirectsToStaffLogin() = testApplication {
+        configureApp(newTestDbUrl())
+        val client = createClient { followRedirects = false }
+
+        val response = client.get("/staff/flights")
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals("/staff/login", response.headers[HttpHeaders.Location])
+    }
+
+    private fun newTestDbUrl(): String {
+        val dbFile = Files.createTempFile("flight-booking-test-", ".db")
+        tempDbFiles.add(dbFile)
+        return "jdbc:sqlite:${dbFile.toAbsolutePath()}"
+    }
+
+    private fun ApplicationTestBuilder.configureApp(dbUrl: String) {
+        environment { config = MapApplicationConfig() }
+        application { testModule(dbUrl) }
+    }
+}


### PR DESCRIPTION
Added a lightweight Ktor server testing baseline with isolated test databases.

- Added test dependencies and JUnit platform config in build.gradle.kts.
- Refactored app startup so test wiring is reusable:
- split server setup into smaller functions
- added testModule(testDbUrl) for test runs
- Made DBFactory.init accept configurable DB URL/driver (defaults unchanged for normal app runs).

- Added integration tests for core auth/access flows:
   - GET /login returns 200
   - unauthenticated /home redirects to /login
   - user register + login redirects correctly and sets session cookie
   - staff register rejects invalid invite code
   - unauthenticated /staff/flights redirects to /staff/login

Why:
Prevents tests from touching the shared local DB and provides a solid starting point for expanding route/database tests safely.