### PR TITLE
Staff tests - Add invalid staff flight creation, Add successful staff flight creation

### DIFF
--- a/src/test/kotlin/com/flightbooking/StaffFlightsRoutesTest.kt
+++ b/src/test/kotlin/com/flightbooking/StaffFlightsRoutesTest.kt
@@ -49,7 +49,35 @@ class StaffFlightsRoutesTest : IntegrationTestSupport() {
 
     @Test
     // Staff should be able to create a flight from the management page.
-    fun createFlightRedirectsWithSuccessMessage() {
+    fun createFlightRedirectsWithSuccessMessage() = testApplication {
+        configureApp()
+        val client = createClient {
+            followRedirects = false
+            install(HttpCookies)
+        }
+        client.get("/__health")
+        val originAirportId = seedAirport("LHR", "London Heathrow")
+        val destinationAirportId = seedAirport("DXB", "Dubai International")
+
+        client.registerStaff()
+        val loginResponse = client.loginStaff()
+        assertEquals(HttpStatusCode.Found, loginResponse.status)
+
+        val response = client.submitForm(
+            url = "/staff/flights/create",
+            formParameters = parameters {
+                append("flightNumber", "101")
+                append("originId", originAirportId.toString())
+                append("destId", destinationAirportId.toString())
+                append("dep", "2026-04-01 09:00:00")
+                append("arr", "2026-04-01 11:00:00")
+                append("status", "scheduled")
+                append("capacity", "180")
+            }
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals("/staff/flights?ok=Flight created", response.headers[HttpHeaders.Location])
     }
 
     @Test

--- a/src/test/kotlin/com/flightbooking/StaffFlightsRoutesTest.kt
+++ b/src/test/kotlin/com/flightbooking/StaffFlightsRoutesTest.kt
@@ -1,5 +1,6 @@
 package com.flightbooking
 
+import com.flightbooking.tables.AirportTable
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
@@ -9,6 +10,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parameters
 import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -51,7 +54,37 @@ class StaffFlightsRoutesTest : IntegrationTestSupport() {
 
     @Test
     // Flight creation should reject invalid route input and redirect with an error.
-    fun createFlightRejectsInvalidRouteData() {
+    fun createFlightRejectsInvalidRouteData() = testApplication {
+        configureApp()
+        val client = createClient {
+            followRedirects = false
+            install(HttpCookies)
+        }
+        client.get("/__health")
+        val airportId = seedAirport("LHR", "London Heathrow")
+
+        client.registerStaff()
+        val loginResponse = client.loginStaff()
+        assertEquals(HttpStatusCode.Found, loginResponse.status)
+
+        val response = client.submitForm(
+            url = "/staff/flights/create",
+            formParameters = parameters {
+                append("flightNumber", "101")
+                append("originId", airportId.toString())
+                append("destId", airportId.toString())
+                append("dep", "2026-04-01 09:00:00")
+                append("arr", "2026-04-01 11:00:00")
+                append("status", "scheduled")
+                append("capacity", "180")
+            }
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals(
+            "/staff/flights?error=Origin and destination cannot be the same",
+            response.headers[HttpHeaders.Location]
+        )
     }
 
     @Test
@@ -97,4 +130,14 @@ class StaffFlightsRoutesTest : IntegrationTestSupport() {
             append("password", password)
         }
     )
+
+    // Insert an airport row so flight-management tests can submit valid airport ids.
+    private fun seedAirport(iataCode: String, name: String): Int = transaction {
+        AirportTable.insert {
+            it[AirportTable.iataCode] = iataCode
+            it[AirportTable.name] = name
+            it[city] = null
+            it[country] = null
+        }.resultedValues!!.first()[AirportTable.id]
+    }
 }


### PR DESCRIPTION
Added staff flight creation coverage for both failure and success paths. These tests verify that invalid route data is rejected with the expected error redirect, while a valid flight creation request succeeds and redirects back to the staff flights page.