### PR TITLE
Added staff dashboard integration tests

### DIFF
--- a/src/test/kotlin/com/flightbooking/StaffDashboardRoutesTest.kt
+++ b/src/test/kotlin/com/flightbooking/StaffDashboardRoutesTest.kt
@@ -1,11 +1,17 @@
 package com.flightbooking
 
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
 import io.ktor.server.testing.testApplication
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class StaffDashboardRoutesTest : IntegrationTestSupport() {
     @Test
@@ -21,11 +27,54 @@ class StaffDashboardRoutesTest : IntegrationTestSupport() {
 
     @Test
     // An authenticated staff user should be able to load the dashboard page.
-    fun authenticatedDashboardLoads() {
+    fun authenticatedDashboardLoads() = testApplication {
+        configureApp()
+        val client = createClient {
+            followRedirects = false
+            install(HttpCookies)
+        }
+
+        client.registerStaff()
+        val loginResponse = client.loginStaff()
+        assertEquals(HttpStatusCode.Found, loginResponse.status)
+        assertEquals("/staff/dashboard", loginResponse.headers[HttpHeaders.Location])
+
+        val response = client.get("/staff/dashboard")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("Staff Dashboard"))
     }
 
     @Test
     // A stale staff session should show a staff-not-found response.
     fun dashboardShowsStaffNotFoundMessageWhenSessionUserIsMissing() {
     }
+
+    // Submit a valid staff registration form for staff dashboard tests.
+    private suspend fun HttpClient.registerStaff(
+        email: String = "staff@example.com",
+        password: String = "StrongPass123!"
+    ) = submitForm(
+        url = "/staff/register",
+        formParameters = parameters {
+            append("firstName", "Alex")
+            append("lastName", "Admin")
+            append("email", email)
+            append("password", password)
+            append("confirmPassword", password)
+            append("role", "admin")
+            append("inviteCode", "STAFF-CHECK")
+        }
+    )
+
+    // Submit a staff login form for authenticated dashboard requests.
+    private suspend fun HttpClient.loginStaff(
+        email: String = "staff@example.com",
+        password: String = "StrongPass123!"
+    ) = submitForm(
+        url = "/staff/login",
+        formParameters = parameters {
+            append("email", email)
+            append("password", password)
+        }
+    )
 }

--- a/src/test/kotlin/com/flightbooking/StaffDashboardRoutesTest.kt
+++ b/src/test/kotlin/com/flightbooking/StaffDashboardRoutesTest.kt
@@ -1,5 +1,6 @@
 package com.flightbooking
 
+import com.flightbooking.tables.StaffTable
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
@@ -9,6 +10,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parameters
 import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.transaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -46,7 +50,22 @@ class StaffDashboardRoutesTest : IntegrationTestSupport() {
 
     @Test
     // A stale staff session should show a staff-not-found response.
-    fun dashboardShowsStaffNotFoundMessageWhenSessionUserIsMissing() {
+    fun dashboardShowsStaffNotFoundMessageWhenSessionUserIsMissing() = testApplication {
+        configureApp()
+        val client = createClient {
+            followRedirects = false
+            install(HttpCookies)
+        }
+
+        client.registerStaff()
+        val loginResponse = client.loginStaff()
+        assertEquals(HttpStatusCode.Found, loginResponse.status)
+
+        deleteStaffByEmail("staff@example.com")
+
+        val response = client.get("/staff/dashboard")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("Staff not found, please login again."))
     }
 
     // Submit a valid staff registration form for staff dashboard tests.
@@ -77,4 +96,9 @@ class StaffDashboardRoutesTest : IntegrationTestSupport() {
             append("password", password)
         }
     )
+
+    // Remove the backing staff row to simulate a stale dashboard session.
+    private fun deleteStaffByEmail(email: String) = transaction {
+        StaffTable.deleteWhere { StaffTable.email eq email }
+    }
 }


### PR DESCRIPTION
Added staff dashboard integration tests. These tests verify that logged-in staff can load the dashboard successfully, and that a session pointing to a missing staff record returns the expected staff-not-found response.