### PR TITLE
User profile display points transactions

### DIFF
--- a/src/main/kotlin/com/flightbooking/routes/PagesRoutes.kt
+++ b/src/main/kotlin/com/flightbooking/routes/PagesRoutes.kt
@@ -2,6 +2,7 @@ package com.flightbooking.routes
 
 import com.flightbooking.access.AirportTableAccess
 import com.flightbooking.access.FlightTableAccess
+import com.flightbooking.access.PointsTableAccess
 import com.flightbooking.models.BookingSession
 import com.flightbooking.models.FlightSearch
 import com.flightbooking.models.FlightWithFares
@@ -240,6 +241,9 @@ private suspend fun handleGetProfile(call: ApplicationCall) {
         }
 
     val pointsBalance = PointsService.getBalance(userId)
+    val pointsTable = PointsTableAccess()
+    val pointsTransactions = pointsTable.getTransactions(userId)
+    println(pointsTransactions)
 
     call.respond(
         PebbleContent(
@@ -247,6 +251,7 @@ private suspend fun handleGetProfile(call: ApplicationCall) {
             mapOf(
                 "userSession" to userSession,
                 "pointsBalance" to pointsBalance,
+                "pointsTransactions" to pointsTransactions,
             ),
         ),
     )

--- a/src/main/resources/static/css/My_Profile.css
+++ b/src/main/resources/static/css/My_Profile.css
@@ -24,6 +24,7 @@ body{
     radial-gradient(900px 600px at 90% 10%, rgba(56,189,248,.12), transparent 55%),
     linear-gradient(180deg, var(--bg0), var(--bg1));
     min-height:100vh;
+    gap: 20px;
 }
 
 nav{
@@ -180,6 +181,9 @@ h1{
     border:1px solid rgba(255,255,255,.10);
     padding:14px;
     min-width:0;
+}
+.points-card {
+    margin-top: 20px;
 }
 .card h2{
     margin:0 0 10px;

--- a/src/main/resources/templates/my_profile.peb
+++ b/src/main/resources/templates/my_profile.peb
@@ -78,6 +78,32 @@
           </aside>
         </div>
 
+        <section class="points-card card">
+          <h2>Points Spending</h2>
+  
+          {% set hasSpending = false %}
+  
+          {% for tx in pointsTransactions %}
+            {% if tx.type == "redeem" %}
+              {% set hasSpending = true %}
+  
+              <div class="row">
+                <div class="v">
+                  {{ tx.points }}
+                </div>
+  
+                <div class="v"> 
+                  <span style="opacity:0.7;">({{ tx.description }})</span>
+                </div>
+              </div>
+  
+            {% endif %}
+          {% endfor %}
+  
+          {% if not hasSpending %}
+            <p class="sub">No points spent yet.</p>
+          {% endif %}
+        </section>
       </main>
     </div>
   </div>


### PR DESCRIPTION
Points transactions are now displayed on the user profile.
Shows inflow and outflow of points spending.
Also provides details on how they spent the points (in case a company own a collective booking account they can track where the points are being spent)