### PR TITLE
when user doesn't select suggestion, falls back onto what user typed

### DIFF
--- a/src/main/resources/static/javascript/Home.js
+++ b/src/main/resources/static/javascript/Home.js
@@ -140,8 +140,6 @@ function initAirportAutocomplete(inputId, dropdownId, hiddenId) {
             flightIndex = (flightIndex - 1 + items.length) % items.length;
             updateActive(items); 
         } else if (e.key === "Enter") {
-            console.log("CLICKED ENTER");
-            console.log(flightIndex);
             e.preventDefault();
             if (flightIndex >= 0 && items[flightIndex]) {
                 items[flightIndex].dispatchEvent(new MouseEvent("mousedown")); // simulate click when entering
@@ -160,6 +158,23 @@ function initAirportAutocomplete(inputId, dropdownId, hiddenId) {
         items[flightIndex]?.scrollIntoView({ block: "nearest" });
     }
 }
+
+document.querySelector("form").addEventListener("submit", (e) => {
+    const originInput = document.getElementById("origin-input");
+    const destinationInput = document.getElementById("destination-input");
+
+    const originHidden = document.getElementById("origin-value");
+    const destinationHidden = document.getElementById("destination-value");
+
+    // If user does not select anything from dropdown, default to using entered text
+    if (!originHidden.value) {
+        originHidden.value = originInput.value;
+    }
+
+    if (!destinationHidden.value) {
+        destinationHidden.value = destinationInput.value
+    }
+})
 
 initAirportAutocomplete("origin-input", "origin-dropdown", "origin-value");
 initAirportAutocomplete("destination-input", "destination-dropdown", "destination-value");


### PR DESCRIPTION
Before:

When user typed in the search box to search a flight origin/destination, the dropdown would appear. If the user did not select an option from the dropdown, the form WOULD NOT fall back on what the user typed, but instead on the default values (London -> London). Thus, even if the user knew what the names of the origin and destination, they still need to waste time clicking on it from the dropdown.

After:

Form now checks whether the hidden fields have been updated. If they have it means that the user has selected an option from the dropdown. Otherwise the user has either typed nothing (which is automatically caught by the HTML require fields tag) or typed a city - which is then submitted instead of the empty hidden fields causing the system to fall onto default values.